### PR TITLE
Cabal and Stack config files added

### DIFF
--- a/hblog.cabal
+++ b/hblog.cabal
@@ -1,0 +1,25 @@
+name:                hblog
+version:             0.1.0
+homepage:            https://github.com/fxfactorial/hblog#readme
+license:             BSD3
+license-file:        LICENSE
+author:              Author name here
+maintainer:          example@example.com
+copyright:           2017 Author name here
+category:            Web
+build-type:          Simple
+extra-source-files:  README.md
+cabal-version:       >=1.10
+
+executable hblog
+  main-is:             hblog.hs
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , filepath
+                     , hakyll
+                     , pandoc
+  default-language:    Haskell2010
+
+source-repository head
+  type:     git
+  location: https://github.com/fxfactorial/hblog

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-8.13


### PR DESCRIPTION
To install make sure you have http://haskellstack.org installed then:

    stack install

then make sure you have the `sass` executable installed before you:

    hblog build
